### PR TITLE
Allow Extra Arguments to be passed

### DIFF
--- a/lib/entry.ex
+++ b/lib/entry.ex
@@ -255,6 +255,9 @@ defmodule Artificery.Entry do
           # Extra arguments, so just dispatch with remaining argv
           new_argv == argv ->
             dispatch(cmd, new_argv, new_flags)
+          # If given extra flag, dispatch immediately.
+          match?(["--extra" | _], new_argv) ->
+            dispatch(cmd, Enum.drop(new_argv, 1), new_flags)
           # Arguments changed during option parsing, so go back to parse_args
           :else ->
             parse_args(new_argv, cmd, new_flags)


### PR DESCRIPTION
This patch is to allow extra arguments to be passed that will not be processed as fruther commands. By adding the `--extra` flag, any arguments after that flag will be passed as argv instead of processed.