### PR TITLE
Fix spinner clear

### DIFF
--- a/lib/console/spinner.ex
+++ b/lib/console/spinner.ex
@@ -146,7 +146,8 @@ defmodule Artificery.Console.Spinner do
     data
   end
   defp clear(%{output: output} = data) do
-    IO.write [Artificery.Console.cursor_up(lines(output)), @erase_down]
+    Artificery.Console.cursor_up(lines(output))
+    IO.write @erase_down
     data
   end
 


### PR DESCRIPTION
When rendering a non-nil status text for a spinner, the escape codes being sent to the terminal were incorrect. This was happening because the output of `Artificery.Console.cursor_up(lines(output))` (`:ok`) was being sent to `IO.write` directly.

The crash due to this error had the following stacktrace:
```
** (ArgumentError) argument error
    (stdlib) :io.put_chars(:standard_io, :unicode, [:ok, "\e[J"])
    (artificery) lib/console/spinner.ex:149: Artificery.Console.Spinner.clear/1
    (artificery) lib/console/spinner.ex:138: Artificery.Console.Spinner.render/1
    (artificery) lib/console/spinner.ex:134: Artificery.Console.Spinner.handle_info/2
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: :tick
```

This PR moves the call to `cursor_up/1` outside of the call to `IO.write`.

@bitwalker I wasn't sure how to properly test this.