### PR TITLE
Avoid compiler and dialyzer warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: elixir
 elixir:
-  - 1.6
+  - 1.7
 otp_release:
-  - 20.0
+  - 21.0
 env:
   - MIX_ENV=test
 script:

--- a/lib/console.ex
+++ b/lib/console.ex
@@ -13,7 +13,7 @@ defmodule Artificery.Console do
   @doc """
   Terminates the process with the given status code
   """
-  @spec halt(non_neg_integer) :: no_return
+  @spec halt(non_neg_integer) :: :ok | no_return
   def halt(code)
 
   def halt(0), do: :ok

--- a/lib/console.ex
+++ b/lib/console.ex
@@ -175,10 +175,10 @@ defmodule Artificery.Console do
           send parent, {self(), {:ok, res}}
         rescue
           err ->
-            send parent, {self(), {:exception, {err, System.stacktrace}}}
+            send parent, {self(), {:exception, {err, __STACKTRACE__}}}
         catch
           type, err ->
-            send parent, {self(), {:error, {type, err, System.stacktrace}}}
+            send parent, {self(), {:error, {type, err, __STACKTRACE__}}}
         end
       end)
       loop.(loop, pid)

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Artificery.MixProject do
     [
       app: :artificery,
       version: "0.4.3",
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),


### PR DESCRIPTION
The function spec used for `Console.halt/1` is missing the `:ok` result that is returned when `0` is passed as the error code.
The deprecated `System.stacktrace/0` function was being used instead of `__STACKTRACE__/0`.