### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 # Used by "mix format"
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # The directory Mix will write compiled artifacts to.
 /_build/
-/.elixir_ls/
 
 # If you run "mix test --cover", coverage assets end up here.
 /cover/
@@ -8,7 +7,7 @@
 # The directory Mix downloads your dependencies sources to.
 /deps/
 
-# Where 3rd-party dependencies like ExDoc output generated docs.
+# Where third-party dependencies like ExDoc output generated docs.
 /doc/
 
 # Ignore .fetch files in case you like to edit your project deps locally.
@@ -23,3 +22,5 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 artificery-*.tar
 
+# Temporary files for e.g. tests.
+/tmp

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 # Artificery
 
-Artificery is a toolkit for generating command line applications. It handles argument parsing, validation/transformation,
-generating help, and provides an easy way to define commands, their arguments, and options.
+[![Module Version](https://img.shields.io/hexpm/v/artificery.svg)](https://hex.pm/packages/artificery)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/artificery/)
+[![Total Download](https://img.shields.io/hexpm/dt/artificery.svg)](https://hex.pm/packages/artificery)
+[![License](https://img.shields.io/hexpm/l/artificery.svg)](https://github.com/bitwalker/artificery/blob/master/LICENSE)
+[![Last Updated](https://img.shields.io/github/last-commit/bitwalker/artificery.svg)](https://github.com/bitwalker/artificery/commits/master)
+
+Artificery is a toolkit for generating command line applications. It handles
+argument parsing, validation/transformation, generating help, and provides an
+easy way to define commands, their arguments, and options.
 
 ## Installation
 
@@ -20,8 +27,8 @@ Then run `mix deps.get` and you are ready to get started!
 
 ## Defining a CLI
 
-Let's assume you have an application named `:myapp`, let's define a module, `MyCliModule` which
-will be the entry point for the command line interface:
+Let's assume you have an application named `:myapp`, let's define a module,
+`MyCliModule` which will be the entry point for the command line interface:
 
 ```elixir
 defmodule MyCliModule do
@@ -29,8 +36,9 @@ defmodule MyCliModule do
 end
 ```
 
-The above will setup the Artificery internals for your CLI, namely it defines an entry point for the command line,
-argument parsing, and imports the macros for defining commands, options, and arguments.
+The above will setup the Artificery internals for your CLI, namely it defines
+an entry point for the command line, argument parsing, and imports the macros
+for defining commands, options, and arguments.
 
 ### Commands
 
@@ -39,19 +47,22 @@ Let's add a simple "hello" command, which will greet the caller:
 ```elixir
 defmodule MyCliModule do
   use Artificery
-  
+
   command :hello, "Says hello" do
     argument :name, :string, "The name of the person to greet", required: true
   end
 end
 ```
 
-We've introduced two of the macros Aritificery imports: `command`, for defining top-level and nested commands; and
-`argument` for defining positional arguments for the current command. **Note**: `argument` can only be used inside of
-`command`, as it applies to the current command being defined, and has no meaning globally.
+We've introduced two of the macros Aritificery imports: `command`, for defining
+top-level and nested commands; and `argument` for defining positional arguments
+for the current command. **Note**: `argument` can only be used inside of
+`command`, as it applies to the current command being defined, and has no
+meaning globally.
 
-This command could be invoked (via escript) like so: `./myapp hello bitwalker`. Right now this will print an error stating
-that the command is defined, but no matching implementation was exported. We define that like so:
+This command could be invoked (via escript) like so: `./myapp hello bitwalker`.
+Right now this will print an error stating that the command is defined, but no
+matching implementation was exported. We define that like so:
 
 ```elixir
 def hello(_argv, %{name: name}) do
@@ -59,12 +70,15 @@ def hello(_argv, %{name: name}) do
 end
 ```
 
-**Note**: Command handlers are expected to have an arity of 2, where the first argument is a list of unhandled arguments/options passed on
-the command line, and the second is a map containing all of the formally defined arguments/options.
+**Note**: Command handlers are expected to have an arity of 2, where the first
+argument is a list of unhandled arguments/options passed on the command line,
+and the second is a map containing all of the formally defined
+arguments/options.
 
-This goes in the same module as the command definition, but you can use `defdelegate` to put the implementation elsewhere. The thing
-to note is that the function needs to be named the same as the command. You can change this however using an extra parameter to `command`,
-like so:
+This goes in the same module as the command definition, but you can use
+`defdelegate` to put the implementation elsewhere. The thing to note is that
+the function needs to be named the same as the command. You can change this
+however using an extra parameter to `command`, like so:
 
 ```elixir
 command :hello, [callback: :say_hello], "Says hello" do
@@ -72,14 +86,15 @@ command :hello, [callback: :say_hello], "Says hello" do
 end
 ```
 
-The above will invoke `say_hello/2` rather than `hello/2**.
+The above will invoke `say_hello/2` rather than `hello/2`.
 
 ### Command Flags
 
-There are two command flags you can set currently to alter some of Artificery's behaviour: `callback: atom` and
-`hidden: boolean`. The former will change the callback function invoked when dispatching a command, as shown above,
-and the latter, when true, will hide the command from display in the `help` output. You may also apply `:hidden` to
-options (but not arguments).
+There are two command flags you can set currently to alter some of Artificery's
+behaviour: `callback: atom` and `hidden: boolean`. The former will change the
+callback function invoked when dispatching a command, as shown above, and the
+latter, when true, will hide the command from display in the `help` output. You
+may also apply `:hidden` to options (but not arguments).
 
 ### Options
 
@@ -106,37 +121,41 @@ And we're done!
 
 ### Subcommands
 
-When you have more complex command line interfaces, it is common to divide up "topics" or top-level commands into subcommands,
-you see this in things like Heroku's CLI, e.g. `heroku keys:add`. Artificery supports this by allowing you to nest `command` 
-within another `command`. Artificery is smart about how it parses arguments, so you can have options/arguments at the top-level
-as well as in subcommands, e.g. `./myapp info --format=json processes`. The options map received by the `processes` command
-will contain all of the options for commands above it.
+When you have more complex command line interfaces, it is common to divide up
+"topics" or top-level commands into subcommands, you see this in things like
+Heroku's CLI, e.g. `heroku keys:add`. Artificery supports this by allowing you
+to nest `command` within another `command`. Artificery is smart about how it
+parses arguments, so you can have options/arguments at the top-level as well as
+in subcommands, e.g. `./myapp info --format=json processes`. The options map
+received by the `processes` command will contain all of the options for
+commands above it.
 
 ```elixir
 defmodule MyCliModule do
   use Artificery
-  
+
   command :info, "Get info about :myapp" do
     option :format, :string, "Sets the output format"
-    
+
     command :processes, "Prints information about processes running in :myapp"
   end
 ```
 
-**Note**: As you may have noticed above, the `processes` command doesn't have a `do` block, because it
-doesn't define any arguments or options, this form is supported for convenience
-
+**Note**: As you may have noticed above, the `processes` command doesn't have a
+`do` block, because it doesn't define any arguments or options, this form is
+supported for convenience.
 
 ### Global Options
 
-You may define global options which apply to all commands by defining them outside `command`:
+You may define global options which apply to all commands by defining them
+outside `command`:
 
 ```elixir
 defmodule MyCliModule do
   use Artificery
-  
+
   option :debug, :boolean, "When set, produces debugging output"
-  
+
   ...
 end
 ```
@@ -146,9 +165,10 @@ and can act accordingly.
 
 ### Reusing Options
 
-You can define reusable options via `defoption/3` or `defoption/4`. These are effectively the same as
-`option/3` and `option/4`, except they do not define an option in any context, they are defined abstractly
-and intended to be used via `option/1` or `option/2`, as shown below:
+You can define reusable options via `defoption/3` or `defoption/4`. These are
+effectively the same as `option/3` and `option/4`, except they do not define an
+option in any context, they are defined abstractly and intended to be used via
+`option/1` or `option/2`, as shown below:
 
 ```elixir
 defoption :host, :string, "The hostname of the server to connect to",
@@ -157,7 +177,7 @@ defoption :host, :string, "The hostname of the server to connect to",
 command :ping, "Pings the host to verify connectivity" do
   # With no overridden flags
   # option :host
-  
+
   # With overrides
   option :host, help: "The host to ping", default: "localhost"
 end
@@ -171,8 +191,8 @@ end
 
 ### Option/Argument Transforms
 
-You can provide transforms for options or arguments to convert them to the data types your commands desire as part of
-the option definition, like so:
+You can provide transforms for options or arguments to convert them to the data
+types your commands desire as part of the option definition, like so:
 
 ```elixir
 # Options
@@ -185,16 +205,18 @@ option :ip, :string, "The IP address of the host to connect to",
         raise "invalid value for --ip, got: #{raw}, error: #{inspect reason}"
     end
   end
-  
+
 # Arguments
 argument :ip, :string, "The IP address of the host to connect to",
   transform: ...
 ```
 
-Now the command (and any subcommands) where this option is defined will get a parsed IP address, rather than
-a raw string, allowing you to do the conversion in one place, rather than in each command handler.
+Now the command (and any subcommands) where this option is defined will get a
+parsed IP address, rather than a raw string, allowing you to do the conversion
+in one place, rather than in each command handler.
 
-Currently this macro supports functions in anonymous form (like in the example above), or one of the following forms:
+Currently this macro supports functions in anonymous form (like in the example
+above), or one of the following forms:
 
 ```elixir
 # Function capture, must have arity 1
@@ -210,12 +232,14 @@ transform: {String, :to_char_list, []}
 
 ### Pre-Dispatch Handling
 
-For those cases where you need to perform some action before command handlers are invoked,
-perhaps to apply global behaviour to all commands, start applications, or whatever else you may need,
-Artificery provides a hook for that, `pre_dispatch/3`.
+For those cases where you need to perform some action before command handlers
+are invoked, perhaps to apply global behaviour to all commands, start
+applications, or whatever else you may need, Artificery provides a hook for
+that, `pre_dispatch/3`.
 
-This is actually a callback defined as part of the `Artificery` behaviour, but is given a default
-implementation. You can override this implementation though to provide your own pre-dispatch step.
+This is actually a callback defined as part of the `Artificery` behaviour, but
+is given a default implementation. You can override this implementation though
+to provide your own pre-dispatch step.
 
 The default implementation is basically the following:
 
@@ -225,40 +249,45 @@ def pre_dispatch(%Artificery.Command{}, _argv, %{} = options) do
 end
 ```
 
-You can either return `{:ok, options}` or raise an error, there are no other choices permitted. This
-allows you to extend or filter `options`, handle additional arguments in `argv`, or take action based
-on the current command.
+You can either return `{:ok, options}` or raise an error, there are no other
+choices permitted. This allows you to extend or filter `options`, handle
+additional arguments in `argv`, or take action based on the current command.
 
 ## Writing Output / Logging
 
-Artificery provides a `Console` module which contains a number of functions for logging or writing output
-to standard out/standard error. A list of basic functions it provides is below:
+Artificery provides a `Console` module which contains a number of functions for
+logging or writing output to standard out/standard error. A list of basic
+functions it provides is below:
 
 - `configure/1`, takes a list of options which configures the logger, currently the only option is `:verbosity`
 - `debug/1`, writes a debug message to stderr (colored cyan if terminal supports color)
 - `info/1`, writes an info message to stdout (no color)
-- `notice/1`, writes an informatinal notice to stdout (bright blue)
+- `notice/1`, writes an informational notice to stdout (bright blue)
 - `success/1`, writes a success message to stdout (bright green)
 - `warn/1`, writes a warning to stderr (yellow)
 - `error/1`, writes an error to stderr (red), and also halts/terminates the process with a non-zero exit code
 
-In addition to writing messages to the terminal, `Console` also provides a way to provide a spinner/loading animation
-while some long-running work is being performed, also supporting the ability to update the message with progress information.
+In addition to writing messages to the terminal, `Console` also provides a way
+to provide a spinner/loading animation while some long-running work is being
+performed, also supporting the ability to update the message with progress
+information.
 
-The following example shows a trivial example of progress, by simply reading from a file in a loop, updating the status
-of the spinner while it reads. There are obviously cleaner ways of writing this, but hopefully it is clear what the capabilities are.
+The following example shows a trivial example of progress, by simply reading
+from a file in a loop, updating the status of the spinner while it reads. There
+are obviously cleaner ways of writing this, but hopefully it is clear what the
+capabilities are.
 
 ```elixir
 def load_data(_argv, %{path: path}) do
   alias Artificery.Console
-  
+
   unless File.exists?(path) do
     Console.error "No such file: #{path}"
   end
-  
+
   # A state machine defined as a recursive anonymous function
   # Each state updates the spinner status and is reflected in the console
-  loader = fn 
+  loader = fn
     :opening, _size, _bytes_read, _file, loader ->
       Console.update_spinner("opening #{path}")
       %{size: size} = File.stat!(path)
@@ -322,13 +351,18 @@ defp is_valid_name(name) when byte_size(name) > 1, do: :ok
 defp is_valid_name(_), do: {:error, "You must tell me your name or I can't greet you!"}
 ```
 
-The above will accept any name more than one character in length, obviously not super robust, but the general idea is shown here.
-The `ask` function also supports transforming responses, and providing defaults in the case where you want to accept blank answers.
+The above will accept any name more than one character in length, obviously not
+super robust, but the general idea is shown here.
+
+The `ask` function also supports transforming responses, and providing defaults
+in the case where you want to accept blank answers.
+
 Check the docs for more information!
 
 ## Producing An Escript
 
-To use your newly created CLI as an escript, simply add the following to your `mix.exs`:
+To use your newly created CLI as an escript, simply add the following to your
+`mix.exs`:
 
 ```elixir
 defp project do
@@ -345,15 +379,17 @@ defp escript do
 end
 ```
 
-The `main_module` to use is the module in which you added `use Artificery`, i.e. the module in
-which you defined the commands your application exposes.
+The `main_module` to use is the module in which you added `use Artificery`,
+i.e. the module in which you defined the commands your application exposes.
 
-Finally, run `mix escript.build` to generate the escript executable. You can then run `./yourapp help` to test it out.
+Finally, run `mix escript.build` to generate the escript executable. You can
+then run `./yourapp help` to test it out.
 
 ## Using In Releases
 
-If you want to define the CLI as part of a larger application, and consume it via custom commands in Distillery, it is
-very straightforward to do. You'll need to define a custom command and add it to your release configuration:
+If you want to define the CLI as part of a larger application, and consume it
+via custom commands in Distillery, it is very straightforward to do. You'll
+need to define a custom command and add it to your release configuration:
 
 ```elixir
 
@@ -374,20 +410,32 @@ Then in `rel/commands/mycli.sh` add the following:
 elixir -e "MyCliModule.main" -- "$@"
 ```
 
-Since the code for your application will already be on the path in a release, we simply need to invoke the CLI module and pass in arguments.
-We add `--` between the `elixir` arguments and those provided from the command line to ensure that they are not treated like arguments to our
-CLI. Artificery handles this, so you simply need to ensure that you add `--` when invoking via `elixir` like this.
+Since the code for your application will already be on the path in a release,
+we simply need to invoke the CLI module and pass in arguments.  We add `--`
+between the `elixir` arguments and those provided from the command line to
+ensure that they are not treated like arguments to our CLI. Artificery handles
+this, so you simply need to ensure that you add `--` when invoking via `elixir`
+like this.
 
-You can then invoke your CLI via the custom command, for example, `bin/myapp mycli help` to print the help text.
+You can then invoke your CLI via the custom command, for example, `bin/myapp
+mycli help` to print the help text.
 
 ## Roadmap
 
 - [ ] Support validators
 
-I'm open to suggestions, just open an issue titled `RFC: <feature you are requesting>`
+I'm open to suggestions, just open an issue titled `RFC: <feature you are requesting>`.
 
 ## License
 
-This project is licensed under Apache 2.0
+Copyright (c) 2018 Paul Schoenfelder
 
-See the LICENSE file in this repository for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/lib/artificery.ex
+++ b/lib/artificery.ex
@@ -70,13 +70,14 @@ defmodule Artificery do
 
 
   @doc """
-  Defines a new command with the given name and either help text or flags
+  Defines a new command with the given name and either help text or flags.
 
-  ## Example
+  ## Examples
 
       command :info, "Displays info about stuff"
 
       command :info, hidden: true
+
   """
   defmacro command(name, help) when is_atom(name) and is_binary(help) do
     quote location: :keep do
@@ -91,9 +92,9 @@ defmodule Artificery do
 
   @doc """
   Defines a new command with the given name, flags or help text, and definition,
-  or flags, help text, and no definition
+  or flags, help text, and no definition.
 
-  ## Example
+  ## Examples
 
       command :info, "Displays info about stuff" do
         ...
@@ -106,6 +107,7 @@ defmodule Artificery do
       command :info, [hidden: true], "Displays info about stuff" do
         ...
       end
+
   """
   defmacro command(name, help, do: block) when is_atom(name) and is_binary(help) do
     quote location: :keep do
@@ -124,13 +126,14 @@ defmodule Artificery do
   end
 
   @doc """
-  Defines a new command with the given name, flags, help text, and definition
+  Defines a new command with the given name, flags, help text, and definition.
 
-  ## Example
+  ## Examples
 
       command :admin, hidden: true, "Does admin stuff" do
         ...
       end
+
   """
   defmacro command(name, flags, help, do: block)
            when is_atom(name) and is_list(flags) and (is_nil(help) or is_binary(help)) do
@@ -226,18 +229,21 @@ defmodule Artificery do
   end
 
   @doc """
-  Defines an option which can be imported into one or more commands. This is an abstract
-  option definition, i.e. it doesn't define an option in any scope, it defines options for reuse.
+  Defines an option which can be imported into one or more commands.
 
-  This macro takes the option name, type, and either help text or options
+  This is an abstract option definition, i.e. it doesn't define an option in
+  any scope, it defines options for reuse.
 
-  Valid types are the same as those defined in `OptionParser`
+  This macro takes the option name, type, and either help text or options.
 
-  ## Example
+  Valid types are the same as those defined in `OptionParser`.
+
+  ## Examples
 
       defoption :verbose, :boolean, "Turns on verbose output"
 
       defoption :verbose, :boolean, hidden: true
+
   """
   defmacro defoption(name, type, flags) when is_atom(name) and is_atom(type) and is_list(flags) do
     quote location: :keep do
@@ -251,11 +257,12 @@ defmodule Artificery do
   end
 
   @doc """
-  Like `defoption/3`, but takes the option name, type, help, and flags
+  Like `defoption/3`, but takes the option name, type, help, and flags.
 
-  ## Example
+  ## Examples
 
       defoption :verbose, :boolean, "Turns on verbose output", hidden: true
+
   """
   defmacro defoption(name, type, help, flags) when is_atom(name) and is_atom(type) and is_list(flags) do
     quote location: :keep do
@@ -280,11 +287,14 @@ defmodule Artificery do
   @doc """
   Imports an option defined via `defoption` into the current scope.
 
-  You may optionally override flags for a given option by passing a keyword list as a second argument.
-  You are not allowed to override the type of the option, but you may override the help text, by passing
-  `help: "..."` as an override. If you need to override the type, it is better if you use `option/3` or `option/4`
+  You may optionally override flags for a given option by passing a keyword
+  list as a second argument.
 
-  ## Example
+  You are not allowed to override the type of the option, but you may override
+  the help text, by passing `help: "..."` as an override. If you need to
+  override the type, it is better if you use `option/3` or `option/4`
+
+  ## Examples
 
       defoption :name, :string, "Name of person"
 
@@ -298,6 +308,7 @@ defmodule Artificery do
         # Import and customize help text
         option :name, help: "Name of the person to greet"
       end
+
   """
   defmacro option(name) when is_atom(name) do
     quote location: :keep do
@@ -310,7 +321,7 @@ defmodule Artificery do
 
       option :foo, :string
 
-  This defines a new option, foo, of type string, with no help or flags defined
+  This defines a new option, foo, of type string, with no help or flags defined.
 
   When used like this:
 
@@ -375,8 +386,11 @@ defmodule Artificery do
   end
 
   @doc """
-  Similar to `defoption`, but defines an option inline. Options defined this way apply either to the global
-  scope, if they aren't nested within a `command` macro, or to the scope of the command they are defined in.
+  Similar to `defoption`, but defines an option inline.
+
+  Options defined this way apply either to the global scope, if they aren't
+  nested within a `command` macro, or to the scope of the command they are
+  defined in.
 
   See `defoption` for usage examples.
   """
@@ -428,11 +442,13 @@ defmodule Artificery do
   end
 
   @doc """
-  Like `option`, but rather than a command switch, it defines a positional argument.
+  Like `option`, but rather than a command switch, it defines a positional
+  argument.
 
-  Beyond the semantics of switches vs positional args, this takes the same configuration as `option` or `defoption`
+  Beyond the semantics of switches vs positional args, this takes the same
+  configuration as `option` or `defoption`.
 
-  ## Example
+  ## Examples
 
       argument :name, :string
   """
@@ -443,13 +459,14 @@ defmodule Artificery do
   end
 
   @doc """
-  Like `argument/2`, but takes either help text or a keyword list of flags
+  Like `argument/2`, but takes either help text or a keyword list of flags.
 
-  ## Example
+  ## Examples
 
       argument :name, :string, "The name to use"
 
       argument :name, :string, required: true
+
   """
   defmacro argument(name, type, help) when is_atom(name) and is_atom(type) and is_binary(help) do
     quote location: :keep do
@@ -463,11 +480,13 @@ defmodule Artificery do
   end
 
   @doc """
-  Like `argument/3`, but takes a name, type, help text and keyword list of flags
+  Like `argument/3`, but takes a name, type, help text and keyword list of
+  flags.
 
-  ## Example
+  ## Examples
 
       argument :name, :string, "The name to use", required: true
+
   """
   defmacro argument(name, type, help, flags) when
     is_atom(name) and is_atom(type) and (is_nil(help) or is_binary(help)) and is_list(flags) do

--- a/lib/command.ex
+++ b/lib/command.ex
@@ -24,7 +24,7 @@ defmodule Artificery.Command do
   }
 
   @doc """
-  Creates a new Command struct, with the given flags applied
+  Creates a new Command struct, with the given flags applied.
   """
   @spec new(atom, map) :: t
   def new(name, flags) when is_map(flags) do
@@ -44,7 +44,7 @@ defmodule Artificery.Command do
   end
 
   @doc """
-  Extends the given Command with a new option
+  Extends the given Command with a new option.
   """
   @spec add_option(t, Artificery.Option.t) :: t
   def add_option(%__MODULE__{options: opts} = c, %Artificery.Option{name: name} = opt) do
@@ -52,7 +52,7 @@ defmodule Artificery.Command do
   end
 
   @doc """
-  Extends the given Command with a new positional argument
+  Extends the given Command with a new positional argument.
   """
   @spec add_argument(t, Artificery.Option.t) :: t
   def add_argument(%__MODULE__{arguments: args} = c, %Artificery.Option{} = arg) do

--- a/lib/console.ex
+++ b/lib/console.ex
@@ -1,5 +1,5 @@
 defmodule Artificery.Console do
-  @moduledoc "A minimal logger"
+  @moduledoc "A minimal logger."
 
   alias __MODULE__.Events
 
@@ -11,7 +11,7 @@ defmodule Artificery.Console do
   #@erase_down @esc <> "J"
 
   @doc """
-  Terminates the process with the given status code
+  Terminates the process with the given status code.
   """
   @spec halt(non_neg_integer) :: :ok | no_return
   def halt(code)
@@ -20,7 +20,7 @@ defmodule Artificery.Console do
   def halt(code) when code > 0 do
     if Application.get_env(:artificery, :no_halt, false) do
       # During tests we don't want to kill the node process,
-      # exit the test process instead
+      # exit the test process instead.
       exit({:halt, code})
     else
       System.halt(code)
@@ -38,12 +38,12 @@ defmodule Artificery.Console do
   end
 
   @doc """
-  Ask the user a question which requires a yes/no answer, returns a boolean
+  Ask the user a question which requires a yes/no answer, returns a boolean.
   """
   defdelegate yes?(question), to: __MODULE__.Prompt
 
   @doc """
-  Ask the user to provide data in response to a question
+  Ask the user to provide data in response to a question.
 
   The value returned is dependent on whether a transformation is applied,
   and whether blank answers are accepted. By default, empty strings will
@@ -65,7 +65,7 @@ defmodule Artificery.Console do
   raw input string the user provided _after_ the validator has validated the input,
   if one was supplied, and if the user input was non-nil.
 
-  Supply default values with the `default: term` option
+  Supply default values with the `default: term` option.
   """
   defdelegate ask(question, opts \\ []), to: __MODULE__.Prompt
 
@@ -73,7 +73,7 @@ defmodule Artificery.Console do
   Write text or iodata to standard output.
 
   You may optionally pass a list of styles to apply to the output, as well
-  as the device to write to (:standard_error, or :stdio)
+  as the device to write to (:standard_error, or :stdio).
   """
   @spec write(iodata) :: :ok
   @spec write(iodata, [atom]) :: :ok
@@ -85,7 +85,7 @@ defmodule Artificery.Console do
   end
 
   @doc """
-  Prints a debug message, only visible when verbose mode is on
+  Prints a debug message, only visible when verbose mode is on.
   """
   @spec debug(String.t()) :: :ok
   @spec debug(:standard_error | :stdio, String.t()) :: :ok
@@ -93,11 +93,11 @@ defmodule Artificery.Console do
     do: log(device, :debug, colorize("==> #{msg}", [:cyan]))
 
   @doc """
-  Prints an info message
+  Prints an info message.
   """
   @spec info(String.t()) :: :ok
   @spec info(:standard_error | :stdio, String.t()) :: :ok
-  def info(device \\ :stdio, msg), 
+  def info(device \\ :stdio, msg),
     do: log(device, :info, msg)
 
   @doc """
@@ -105,7 +105,7 @@ defmodule Artificery.Console do
   """
   @spec notice(String.t()) :: :ok
   @spec notice(:standard_error | :stdio, String.t()) :: :ok
-  def notice(device \\ :stdio, msg), 
+  def notice(device \\ :stdio, msg),
     do: log(device, :info, colorize(msg, [:bright, :blue]))
 
   @doc """
@@ -113,7 +113,7 @@ defmodule Artificery.Console do
   """
   @spec success(String.t()) :: :ok
   @spec success(:standard_error | :stdio, String.t()) :: :ok
-  def success(device \\ :stdio, msg), 
+  def success(device \\ :stdio, msg),
     do: log(device, :warn, colorize(msg, [:bright, :green]))
 
   @doc """
@@ -121,11 +121,11 @@ defmodule Artificery.Console do
   """
   @spec warn(String.t()) :: :ok
   @spec warn(:standard_error | :stdio, String.t()) :: :ok
-  def warn(device \\ :stdio, msg), 
+  def warn(device \\ :stdio, msg),
     do: log(device, :warn, colorize(msg, [:yellow]))
 
   @doc """
-  Prints an error message, and then halts the process
+  Prints an error message, and then halts the process.
   """
   @spec error(String.t()) :: no_return
   @spec error(:standard_error | :stdio, String.t()) :: no_return
@@ -139,13 +139,14 @@ defmodule Artificery.Console do
 
   ## Options
 
-  - spinner: one of the spinners defined in Artificery.Console.Spinner
+    * `:spinner` - one of the spinners defined in Artificery.Console.Spinner
 
-  ## Example
+  ## Examples
 
       Console.spinner "Loading...", [spinner: :simple_dots] do
         :timer.sleep(5_000)
       end
+
   """
   defmacro spinner(msg, opts \\ [], do: block) when is_binary(msg) do
     quote location: :keep do
@@ -186,14 +187,14 @@ defmodule Artificery.Console do
   end
 
   @doc """
-  Updates a running spinner with the provided status text
+  Updates a running spinner with the provided status text.
   """
   @spec update_spinner(String.t) :: :ok
   def update_spinner(status) when is_binary(status) do
     Artificery.Console.Spinner.status(status)
   end
 
-  # Used for tests
+  # Used for tests.
   @doc false
   def update_spinner(spinner, status) do
     Artificery.Console.Spinner.status(spinner, status)
@@ -205,35 +206,35 @@ defmodule Artificery.Console do
   @doc false
   def hide_cursor(), do: IO.write([@cursor_hide])
 
-  # Move the cursor up the screen by `n` lines
+  # Move the cursor up the screen by `n` lines.
   @doc false
   def cursor_up(n), do: IO.write([@esc, "#{n}A"])
 
-  # Move the cursor down the screen by `n` lines
+  # Move the cursor down the screen by `n` lines.
   @doc false
   def cursor_down(n), do: IO.write([@esc, "#{n}B"])
 
-  # Move the cursor right on the screen by `n` columns
+  # Move the cursor right on the screen by `n` columns.
   @doc false
   def cursor_forward(n), do: IO.write([@esc, "#{n}C"])
 
-  # Move the cursor left on the screen by `n` columns
+  # Move the cursor left on the screen by `n` columns.
   @doc false
   def cursor_backward(n), do: IO.write([@esc, "#{n}D"])
 
-  # Move the cursor to the next line
+  # Move the cursor to the next line.
   @doc false
   def cursor_next_line, do: IO.write([@esc, "E"])
 
-  # Move the cursor to the previous line
+  # Move the cursor to the previous line.
   @doc false
   def cursor_prev_line, do: IO.write([@esc, "F"])
 
-  # Erases the current line, placing the cursor at the beginning
+  # Erases the current line, placing the cursor at the beginning.
   @doc false
   def erase_line, do: IO.write([@cursor_left, @erase_line])
 
-  # Erases `n` lines starting at the current line and going up the screen
+  # Erases `n` lines starting at the current line and going up the screen.
   @doc false
   def erase_lines(0), do: ""
   def erase_lines(n) when is_integer(n) do

--- a/lib/console/color.ex
+++ b/lib/console/color.ex
@@ -24,7 +24,7 @@ defmodule Artificery.Console.Color do
   any of those found in `IO.ANSI`, such as `:faint` or `:cyan`, and also
   supports `:dim` as an alias for `:faint`, as well as `:grey` or `:gray`.
 
-  Returns a formatted binary
+  Returns a formatted binary.
   """
   @spec style(binary, [atom]) :: binary
   def style(msg, styles) when is_list(styles) do
@@ -51,7 +51,7 @@ defmodule Artificery.Console.Color do
   end
 
   @doc """
-  Returns true if the current terminal supports color output, false if not
+  Returns true if the current terminal supports color output, false if not.
   """
   @spec supports_color?() :: boolean
   def supports_color? do
@@ -59,7 +59,8 @@ defmodule Artificery.Console.Color do
   end
 
   @doc """
-  Returns true if the current terminal supports 256bit color output, false if not
+  Returns true if the current terminal supports 256bit color output, false if
+  not.
   """
   @spec supports_256color?() :: boolean
   def supports_256color? do
@@ -67,7 +68,8 @@ defmodule Artificery.Console.Color do
   end
 
   @doc """
-  Returns true if the current terminal supports 16M bit color output, false if not
+  Returns true if the current terminal supports 16M bit color output, false if
+  not.
   """
   @spec supports_truecolor?() :: boolean
   def supports_truecolor? do

--- a/lib/console/events.ex
+++ b/lib/console/events.ex
@@ -4,28 +4,28 @@ defmodule Artificery.Console.Events do
   @behaviour :gen_event
 
   @doc """
-  Start listening for console events
+  Start listening for console events.
   """
   def start do
     :gen_event.add_handler(:erl_signal_server, __MODULE__, [])
   end
 
   @doc """
-  Stop listening for console events
+  Stop listening for console events.
   """
   def stop do
     :gen_event.delete_handler(:erl_signal_server, __MODULE__, :normal)
   end
 
   @doc """
-  Subscribe the current process to event notifications
+  Subscribe the current process to event notifications.
   """
   def subscribe do
     :gen_event.call(:erl_signal_server, __MODULE__, {:subscribe, self()})
   end
 
   @doc """
-  Unsubscribe the current process from event notifications
+  Unsubscribe the current process from event notifications.
   """
   def unsubscribe do
     :gen_event.call(:erl_signal_server, __MODULE__, {:unsubscribe, self()})

--- a/lib/console/table.ex
+++ b/lib/console/table.ex
@@ -1,5 +1,7 @@
 defmodule Artificery.Console.Table do
-  @moduledoc "A printer for tabular data"
+  @moduledoc """
+  A printer for tabular data.
+  """
 
   @doc """
   Given a title, header, and rows, prints the data as a table.
@@ -15,9 +17,9 @@ defmodule Artificery.Console.Table do
 
   Takes an optional keyword list of options:
 
-  - `padding: integer` sets the padding around columns
+    * `:padding` - (integer) sets the padding around columns
 
-  This function formats the data as iodata, it is up to the caller to print it
+  This function formats the data as iodata, it is up to the caller to print it.
   """
   def format(title, header, rows, opts \\ []) do
     padding = Keyword.get(opts, :padding, 1)

--- a/lib/entry.ex
+++ b/lib/entry.ex
@@ -28,7 +28,8 @@ defmodule Artificery.Entry do
       @doc """
       Main entry point for this script.
 
-      Handles parsing and validating arguments, then dispatching the selected command
+      Handles parsing and validating arguments, then dispatching the selected
+      command.
       """
       def main() do
         argv =
@@ -151,7 +152,7 @@ defmodule Artificery.Entry do
             )
 
           # This means the current argument is not a subcommand name,
-          # but should instead be considered a positional argument
+          # but should instead be considered a positional argument.
           nil when has_arguments ->
             # Pop the first argument off
             [arg | arguments] = arguments
@@ -185,8 +186,8 @@ defmodule Artificery.Entry do
             # Recur by removing an argument from the stack and updating the flags
             parse_args(argv, %{context_cmd | arguments: arguments}, new_flags)
 
-          # No subcommands and no defined positional arguments
-          # Just pass the plain argv to the command in case it wants them
+          # No subcommands and no defined positional arguments.
+          # Just pass the plain argv to the command in case it wants them.
           nil ->
             post_process_command(context_cmd, oargv, flags)
 
@@ -218,7 +219,8 @@ defmodule Artificery.Entry do
 
         parser_opts = [strict: switches, aliases: aliases]
 
-        # Split on -- so we can properly handle passing raw arguments to commands
+        # Split on -- so we can properly handle passing raw arguments to
+        # commands.
         {argv, extra_argv} =
           Enum.split_while(argv, fn
             "--" -> false
@@ -370,7 +372,7 @@ defmodule Artificery.Entry do
         command_path =
           case extract_command_path(commands, [command_name | argv], []) do
             [] ->
-              # Not actually a subcommand path, so print top level help
+              # Not actually a subcommand path, so print top level help.
               print_help([])
 
             path ->
@@ -382,7 +384,7 @@ defmodule Artificery.Entry do
           |> Enum.map(&Atom.to_string/1)
           |> Enum.join(" ")
 
-        # Validate command
+        # Validate command.
         cmd = get_in(commands, Enum.intersperse(command_path, :subcommands))
 
         if is_nil(cmd) do

--- a/lib/option.ex
+++ b/lib/option.ex
@@ -31,7 +31,7 @@ defmodule Artificery.Option do
   ]
 
   @doc """
-  Creates a new Option struct
+  Creates a new Option struct.
   """
   @spec new(atom, map) :: t
   def new(name, flags) when is_atom(name) and is_map(flags) do
@@ -47,7 +47,7 @@ defmodule Artificery.Option do
   end
 
   @doc """
-  Validates the Option struct, raising an error if invalid
+  Validates the Option struct, raising an error if invalid.
   """
   @spec validate!(t, [caller: module]) :: :ok | no_return
   def validate!(%__MODULE__{flags: flags}, caller: caller) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,8 @@
 defmodule Artificery.MixProject do
   use Mix.Project
 
+  @source_url "https://github.com/bitwalker/artificery"
+
   def project do
     [
       app: :artificery,
@@ -8,6 +10,7 @@ defmodule Artificery.MixProject do
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      docs: docs(),
       description: description(),
       package: package(),
       elixirc_paths: elixirc_paths(Mix.env),
@@ -30,16 +33,23 @@ defmodule Artificery.MixProject do
     ]
   end
 
+  defp docs do
+    [
+      extras: ["README.md"],
+      main: "readme"
+    ]
+  end
+
   defp description, do: "A toolkit for terminal user interfaces in Elixir"
 
   defp package do
     [
       files: ["lib", "mix.exs", "README.md", "LICENSE.md"],
       maintainers: ["Paul Schoenfelder"],
-      licenses: ["Apache 2.0"],
+      licenses: ["Apache-2.0"],
       links: %{
-        GitHub: "https://github.com/bitwalker/artificery",
-        Issues: "https://github.com/bitwalker/artificery/issues"
+        GitHub: @source_url,
+        Issues: @source_url <> "/issues"
       }
     ]
   end


### PR DESCRIPTION
Besides other changes, this commit ensures the generated HTML doc for
HexDocs.pm will become the main doc source for this Elixir library.

List of changes:
* Set readme as main html doc
* Fix markdowns
* Fix typos
* Update gitignore
* Update formatter config
* Use common source url
* Fix spdx license id
* Update license section
* Badges and more badges!

Screenshot:

![Screenshot-20210219225948-2662x1430](https://user-images.githubusercontent.com/134518/108521042-4a640900-7306-11eb-852e-abe067ea426d.png)
