### PR TITLE
1.18 elixir deprecation fix

### DIFF
--- a/lib/console/table.ex
+++ b/lib/console/table.ex
@@ -58,7 +58,7 @@ defmodule Artificery.Console.Table do
   defp stringify([], acc), do: Enum.reverse(acc)
   defp stringify([row | rest], acc), do: stringify(rest, [Enum.map(row, &to_string/1) | acc])
 
-  defp transpose(rows), do: rows |> List.zip() |> Enum.map(&Tuple.to_list/1)
+  defp transpose(rows), do: rows |> Enum.zip() |> Enum.map(&Tuple.to_list/1)
 
   defp column_widths(cols) do
     Enum.map(cols, fn c -> c |> Enum.map(&byte_size/1) |> Enum.max() end)

--- a/lib/entry.ex
+++ b/lib/entry.ex
@@ -586,7 +586,7 @@ defmodule Artificery.Entry do
           items
           |> Enum.map(&Tuple.to_list/1)
           |> Enum.map(fn cols -> Enum.map(cols, &byte_size/1) end)
-          |> List.zip()
+          |> Enum.zip()
           |> Enum.map(&Tuple.to_list/1)
 
         acc = :erlang.make_tuple(length(cols), 0)


### PR DESCRIPTION
https://elixirforum.com/t/elixir-v1-18-0-released/68248
[List] List.zip/1 is deprecated in favor of Enum.zip/1

This fix removes deprecation warnings